### PR TITLE
Fix: preinscripcion bugs 8

### DIFF
--- a/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/descuento_academico/crud-descuento-academico/crud-descuento-academico.component.ts
+++ b/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/descuento_academico/crud-descuento-academico/crud-descuento-academico.component.ts
@@ -235,7 +235,7 @@ export class CrudDescuentoAcademicoComponent implements OnInit {
                   this.info_descuento_academico.DescuentoDependencia.Periodo = Number(window.sessionStorage.getItem('IdPeriodo'));
           
                   this.info_descuento_academico.DescuentosDependenciaId = this.info_descuento_academico.DescuentoDependencia;
-                  this.inscripcionMidService.put('academico/descuento/', this.info_descuento_academico)
+                  this.inscripcionMidService.put('academico/descuento', this.info_descuento_academico)
                     .subscribe(res => {
                       /* if (documentos_actualizados['SoporteDescuento'] !== undefined) {
                         this.info_descuento_academico.Documento = documentos_actualizados['SoporteDescuento'].url + '';

--- a/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/documento-programa/list-documento-programa/list-documento-programa.component.ts
+++ b/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/documento-programa/list-documento-programa/list-documento-programa.component.ts
@@ -80,6 +80,7 @@ export class ListDocumentoProgramaComponent implements OnInit {
   async loadData() {
     // Inicializar soporteDocumento y dataSource al principio del método
     this.soporteDocumento = [];
+    this.listAlreadyUploaded = [];
     this.dataSource.data = this.soporteDocumento;
     this.percentage = 0;
 

--- a/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/idiomas/crud-idiomas/crud-idiomas.component.ts
+++ b/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/idiomas/crud-idiomas/crud-idiomas.component.ts
@@ -148,7 +148,7 @@ export class CrudIdiomasComponent implements OnInit {
               r.Type !== 'error' &&
               JSON.stringify(res[0]).toString() !== '{}'
             ) {
-              this.idioma_examen = r.Idioma;
+              this.idioma_examen = r[0].Idioma;
             }
           },
           (error: HttpErrorResponse) => {
@@ -167,6 +167,7 @@ export class CrudIdiomasComponent implements OnInit {
   }
 
   createInfoIdioma(infoIdioma: any): void {
+    this.info_idioma = undefined;
     this.popUpManager
       .showConfirmAlert(
         this.translate.instant('idiomas.seguro_continuar_registrar'),
@@ -175,6 +176,7 @@ export class CrudIdiomasComponent implements OnInit {
       .then((willDelete) => {
         if (willDelete.value) {
           this.info_idioma = <InfoIdioma>infoIdioma;
+          console.log(this.info_idioma);
           if (this.info_idioma.Nativo != true) {
             this.info_idioma.Nativo = false;
           }
@@ -193,8 +195,11 @@ export class CrudIdiomasComponent implements OnInit {
             this.info_idioma.SeleccionExamen === true &&
             this.idioma_examen !== undefined
           ) {
+            console.log("idioma_examen",this.idioma_examen)
+            const nombre = this.formInfoIdioma.campos[this.getIndexForm('IdiomaId')].opciones.find((idioma: any) => idioma.Id === this.idioma_examen)?.Nombre;
+            console.log("idiomas",this.formInfoIdioma.campos[this.getIndexForm('IdiomaId')].opciones)
             this.popUpManager.showErrorAlert(
-              this.translate.instant('idiomas.error_doble_examen')
+              this.translate.instant('idiomas.error_doble_examen')+ " : "+ nombre
             );
           } else {
             this.idiomaService

--- a/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/produccion-academica/list-produccion-academica/list-produccion-academica.component.ts
+++ b/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/components/inscripcion-general/tabs/produccion-academica/list-produccion-academica/list-produccion-academica.component.ts
@@ -114,6 +114,7 @@ export class ListProduccionAcademicaComponent implements OnInit {
   }
 
   onEdit(event: any): void {
+    this.prod_selected = undefined;
     if (
       event.EstadoEnteAutorId.EstadoAutorProduccionId.Id === 1 ||
       event.EstadoEnteAutorId.EstadoAutorProduccionId.Id === 2

--- a/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/crud-inscripcion-multiple.component.ts
+++ b/src/app/modules/preinscripcion/preinscripcion/components/crud-inscripcion-multiple/crud-inscripcion-multiple.component.ts
@@ -298,7 +298,7 @@ export class CrudInscripcionMultipleComponent implements OnInit {
     this.showInscription = false;
   }
 
-  onRenderButtonPaymentComponent(data: any) {
+  async onRenderButtonPaymentComponent(data: any) {
     sessionStorage.setItem('EstadoInscripcion', data.estado);
     // Solamente se usa esta linea para pruebas saltaldo el pago de recibo
     // sessionStorage.setItem('EstadoInscripcion', 'true');
@@ -309,79 +309,77 @@ export class CrudInscripcionMultipleComponent implements OnInit {
         'IdEstadoInscripcion',
         data.data.EstadoInscripcion
       );
-      this.itemSelect({ data: data.data });
+      await this.itemSelect({ data: data.data });
     }
   }
 
-  itemSelect(event: any): void {
-    sessionStorage.setItem('IdInscripcion', event.data.Id);
-    this.inscripcionService
-      .get('inscripcion/' + event.data.Id)
-      .subscribe((response: any) => {
-        this.projectService
-          .get(
-            `proyecto_academico_institucion?limit=0&query=Id:${response.ProgramaAcademicoId},Activo:true&fields=Id,Nombre,NivelFormacionId,Codigo`
-          )
-          .subscribe(
-            (response2: any) => {
-              if (response2) {
-                if (response2[0].NivelFormacionId.CodigoAbreviacion == 'PRE') {
-                  console.log('Pregrado', response.TipoInscripcionId.Id);
-                  sessionStorage.setItem(
-                    'ProgramaAcademico',
-                    event.data.ProgramaAcademicoId
-                  );
-                  sessionStorage.setItem('IdPeriodo', response.PeriodoId);
-                  sessionStorage.setItem(
-                    'IdTipoInscripcion',
-                    response.TipoInscripcionId.Id
-                  );
-                  sessionStorage.setItem(
-                    'ProgramaAcademicoId',
-                    response.ProgramaAcademicoId
-                  );
-                  sessionStorage.setItem('IdEnfasis', response.EnfasisId);
-                  const EstadoIns = sessionStorage.getItem('EstadoInscripcion');
-                  if (EstadoIns === 'true') {
-                    this.nivelInscripcion = true;
-                    this.loadInscriptionModule();
-                  }
-                } else {
-                  console.log('Posgrado', response.TipoInscripcionId.Id);
-                  sessionStorage.setItem(
-                    'ProgramaAcademico',
-                    event.data.ProgramaAcademicoId
-                  );
-                  sessionStorage.setItem('IdPeriodo', response.PeriodoId);
-                  sessionStorage.setItem(
-                    'IdTipoInscripcion',
-                    response.TipoInscripcionId.Id
-                  );
-                  sessionStorage.setItem(
-                    'ProgramaAcademicoId',
-                    response.ProgramaAcademicoId
-                  );
-                  sessionStorage.setItem('IdEnfasis', response.EnfasisId);
-                  const EstadoIns = sessionStorage.getItem('EstadoInscripcion');
-                  if (EstadoIns === 'true') {
-                    this.nivelInscripcion = false;
-                    this.loadInscriptionModule();
-                  }
-                }
-              } else {
-                this.popUpManager.showErrorToast(
-                  this.translate.instant('ERROR.general')
-                );
-              }
-            },
-            (error: any) => {
-              console.error(error);
-              this.popUpManager.showErrorToast(
-                this.translate.instant('ERROR.general')
-              );
-            }
+  async itemSelect(event: any): Promise<void> {
+    try {
+      sessionStorage.setItem('IdInscripcion', event.data.Id);
+
+      const response = await this.inscripcionService
+        .get('inscripcion/' + event.data.Id)
+        .toPromise();
+
+      const response2 = await this.projectService
+        .get(
+          `proyecto_academico_institucion?limit=0&query=Id:${response.ProgramaAcademicoId},Activo:true&fields=Id,Nombre,NivelFormacionId,Codigo`
+        )
+        .toPromise();
+
+      if (response2) {
+        if (response2[0].NivelFormacionId.CodigoAbreviacion == 'PRE') {
+          console.log('Pregrado', response.TipoInscripcionId.Id);
+          sessionStorage.setItem(
+            'ProgramaAcademico',
+            event.data.ProgramaAcademicoId
           );
-      });
+          sessionStorage.setItem('IdPeriodo', response.PeriodoId);
+          sessionStorage.setItem(
+            'IdTipoInscripcion',
+            response.TipoInscripcionId.Id
+          );
+          sessionStorage.setItem(
+            'ProgramaAcademicoId',
+            response.ProgramaAcademicoId
+          );
+          sessionStorage.setItem('IdEnfasis', response.EnfasisId);
+          const EstadoIns = sessionStorage.getItem('EstadoInscripcion');
+          if (EstadoIns === 'true') {
+            this.nivelInscripcion = true;
+            this.loadInscriptionModule();
+          }
+        } else {
+          console.log('Posgrado', response.TipoInscripcionId.Id);
+          sessionStorage.setItem(
+            'ProgramaAcademico',
+            event.data.ProgramaAcademicoId
+          );
+          sessionStorage.setItem('IdPeriodo', response.PeriodoId);
+          sessionStorage.setItem(
+            'IdTipoInscripcion',
+            response.TipoInscripcionId.Id
+          );
+          sessionStorage.setItem(
+            'ProgramaAcademicoId',
+            response.ProgramaAcademicoId
+          );
+          sessionStorage.setItem('IdEnfasis', response.EnfasisId);
+          const EstadoIns = sessionStorage.getItem('EstadoInscripcion');
+          if (EstadoIns === 'true') {
+            this.nivelInscripcion = false;
+            this.loadInscriptionModule();
+          }
+        }
+      } else {
+        this.popUpManager.showErrorToast(
+          this.translate.instant('ERROR.general')
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+    }
   }
 
   useLanguage(language: string) {
@@ -561,7 +559,8 @@ export class CrudInscripcionMultipleComponent implements OnInit {
         });
       }
 
-      const proyectosResponse: any = await this.recuperarProyectosAcademicosInstitucion();
+      const proyectosResponse: any =
+        await this.recuperarProyectosAcademicosInstitucion();
       this.projects = proyectosResponse;
 
       // Encontrar los niveles de formación únicos
@@ -619,7 +618,6 @@ export class CrudInscripcionMultipleComponent implements OnInit {
         );
     });
   }
-
 
   nuevaPreinscripcion() {
     this.showNew = true;
@@ -873,16 +871,13 @@ export class CrudInscripcionMultipleComponent implements OnInit {
     return new Promise((resolve, reject) => {
       this.inscripcionMidService.post('inscripciones/nueva', body).subscribe(
         (response: any) => {
-          console.log("LA RESPUESTA NUEVA", response)
           if (response.Status == 200 && response.Success) {
             this.popUpManager.showSuccessAlert(
               this.translate.instant('recibo_pago.generado')
             );
             resolve(true);
           } else if (response.Status == 200 && !response.Success) {
-            this.popUpManager.showErrorAlert(
-              response.Message
-            );
+            this.popUpManager.showErrorAlert(response.Message);
             reject(false);
           } else if (response.Status == 400) {
             this.popUpManager.showErrorToast(
@@ -902,8 +897,8 @@ export class CrudInscripcionMultipleComponent implements OnInit {
     });
   }
 
-  descargarReciboPago(data: any) {
-    this.itemSelect({ data: data });
+  async descargarReciboPago(data: any) {
+    await this.itemSelect({ data: data });
     if (this.selectedLevel === undefined) {
       this.selectedLevel = parseInt(data.NivelPP, 10);
     }


### PR DESCRIPTION
- Se modificó el método onRenderButtonPaymentComponent para que sea asíncrono y se utilice la palabra clave "await" al llamar al método itemSelect. También se modificó el método itemSelect para que sea asíncrono y se utilice la palabra clave "await" al llamar a los servicios inscripcionService y projectService. Esto mejora la legibilidad y el manejo de errores en el código. Esto elimina el error de no poder ver el recibo de pago la primera ves que se hace click.
- Eliminado `/` en el PUTde academico/descuento//123
- Tab de documentos: Cuando se eliminaba un documento y se queria volver agregar se mostraba una alerta de que el recurso ya se encontraba registrado sin permitir registrar de nuevo el documento.
- En produccion academica se intenta resetear el valor.
- Tab idioma: Cuando se quiere quitar la relacion en inscripcion_posgrado pone por default el valor 0, el cual es el idioma español. Al colocar una valor de 0, de todas maneras queda asociado a un idioma por ende no se permite agregar otro idioma con el check de ` ¿Desea usar este idioma para su examen?`.
---
udistrital/sga_documentacion#509